### PR TITLE
[PGE-178206549] Doc Update related to new Prebid Adapter

### DIFF
--- a/dev-docs/bidders/sharethrough.md
+++ b/dev-docs/bidders/sharethrough.md
@@ -6,7 +6,7 @@ description: Prebid Sharethrough Adaptor
 gdpr_supported: true
 coppa_supported: true
 floors_supported: true
-media_types: video
+media_types: banner, video
 safeframes_ok: true
 schain_supported: true
 userIds: pubCommonId, unifiedId, identityLink, id5Id, sharedId, liveIntentId
@@ -23,10 +23,7 @@ The Sharethrough bidder adapter requires additional setup and approval from the 
 
 {: .table .table-bordered .table-striped }
 | Name        | Scope    | Description                                                                                                                                                                      | Example                      | Type                 |
-|-------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|----------------------|
-| `bidfloor`  | optional | The floor price, or minimum amount, a publisher will accept for an impression, given in CPM in USD.                                                                              | `1.00`                       | `float`              |
-| `iframe`    | optional | If `true`, the ad will render in an iframe. Defaults to `false`.                                                                                                                 | `true`                       | `boolean`            |
-| `iframeSize`| optional | `[width, height]` If provided, use this size for the iframe size. Only applicable if `iframe` is `true`. If omitted, the largest size from the ad unit sizes array will be used. | `[300, 250]`                 | `[integer, integer]` |
-| `bcat`      | optional | Array of blocked IAB Categories                                                                                                                                                  | `['IAB1-2', 'IAB1-3']`       | `string[]`           |
-| `badv`      | optional | Array of blocked Advertisers by their domains                                                                                                                                    | `['ford.com', 'pepsi.com']`  | `string[]`           |
-| `pkey`      | required | The placement key                                                                                                                                                                | `'DfFKxpkRGPMS7A9f71CquBgZ'` | `string`             |
+|-------------|----------|-----------------------------------------------|------------------------------|----------------------|
+| `pkey`      | required | The placement key                             | `'DfFKxpkRGPMS7A9f71CquBgZ'` | `string`             |
+| `bcat`      | optional | Array of blocked IAB Categories               | `['IAB1-2', 'IAB1-3']`       | `string[]`           |
+| `badv`      | optional | Array of blocked Advertisers by their domains | `['ford.com', 'pepsi.com']`  | `string[]`           |

--- a/dev-docs/bidders/sharethrough.md
+++ b/dev-docs/bidders/sharethrough.md
@@ -9,7 +9,7 @@ floors_supported: true
 media_types: banner, video
 safeframes_ok: true
 schain_supported: true
-userIds: pubCommonId, unifiedId, identityLink, id5Id, sharedId, liveIntentId
+userIds: all
 usp_supported: true
 fpd_supported: true
 pbjs: true


### PR DESCRIPTION
Everything was pretty much already up to date, since the doc is shared across PBjs and PB Server. What is changing:
- explicitly add banner to supported media types, it's implicitly always enabled but I prefer make it clearer
- remove custom params that are not supported anymore, iframe related values and floor (we switched to floor module)

https://sharethrough.atlassian.net/browse/PGE-178206549
https://sharethrough.atlassian.net/browse/PGE-178206596